### PR TITLE
Add lanelet2 deps to carma-base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,11 @@ RUN apt-get update && \
         gcovr \
         libpcap-dev \
         libfftw3-dev \
-        gnuplot-qt
+        gnuplot-qt \
+        libgeographic-dev \ 
+        libpugixml-dev \
+        python-catkin-tools \
+        libboost-python-dev
 
 RUN pip3 install -U setuptools
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
 -->
 <package format="2">
   <name>carma_base</name>
-  <version>3.3.0</version>
+  <version>3.4.0</version>
 
   <description>
         A metapackage to install the dependencies for CARMA


### PR DESCRIPTION
This PR adds the dependencies for lanelet2 to the carma-base image. Additionally, updates the carma-base version number as we will follow this with a component release. 

Part of addressing: usdot-fhwa-stol/CARMAPlatform#419