### PR TITLE
Add truck angle sensor (lidar lite) dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,9 @@ RUN apt-get update && \
         libboost-python-dev \
         sqlite3 \
         autotools-dev \
-        automake
+        automake \
+        ros-kinetic-rosserial-arduino \
+        ros-kinetic-rosserial
 
 RUN pip3 install -U setuptools
 


### PR DESCRIPTION
Adds the dependencies of the trailer angle sensor driver found in the usdot-fhwa-stol/CARMAGarminLidarLiteV3DriverWrapper. 
This is needed to help address usdot-fhwa-stol/CARMAPlatform#488