### PR TITLE
CARMABase 2.7.1

### DIFF
--- a/code_coverage/collect_gcovr.bash
+++ b/code_coverage/collect_gcovr.bash
@@ -55,7 +55,7 @@ else
 	output_dir=$2;
 fi
 
-gcovr -k -r . # Run gcovr with -k to ensure generated .gcov files are preserved -r . makes it run in the current directory
+gcovr --sonarqube -k -r . # Run gcovr with -k to ensure generated .gcov files are preserved -r . makes it run in the current directory
 
 echo "Ensuring output directory exists"
 mkdir -p ${output_dir}


### PR DESCRIPTION
Bugfix component release to fix sonarqube failure. Only change is adding `--sonarqube` to gcov command.