### PR TITLE
Update SSL certificates in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,11 @@ ENV ROS_DISTRO kinetic
 RUN sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'     \ 
     && apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654     \ 
     && apt-get update     \ 
-    && apt-get install ros-kinetic-desktop-full python-rosinstall -y
+    && apt-get install  \
+       openssl \
+       ca-certificates \
+       ros-kinetic-desktop-full \
+       python-rosinstall -y
 
 RUN apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -133,7 +137,7 @@ RUN sudo git clone --depth 1 https://github.com/vishnubob/wait-for-it.git ~/.bas
 
 # Install Armadillo
 RUN cd ~/ && \
-        curl -L  http://sourceforge.net/projects/arma/files/armadillo-9.800.1.tar.xz > armadillo-9.800.1.tar.xz && \
+        curl -Lk  http://sourceforge.net/projects/arma/files/armadillo-9.800.1.tar.xz > armadillo-9.800.1.tar.xz && \
         tar -xvf armadillo-9.800.1.tar.xz && \
         cd armadillo-9.800.1 && \
         ./configure && \


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Updates the SSL certificates trusted by the installed OpenSSL version to account for the expiry of the "Let's Encrypt" certificate as of Sept 30th. 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
carma-base and autoware cannot compile succesfully in docker without these changes as they fail to download their dependencies during docker build.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally by building the docker images for carma-base and autoware.ai and verifying that they download QPOASES and armadillo successfully. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
